### PR TITLE
Add support for image shortcodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ __2023-10__
 
 * Add support for Google Analytics v4
 * Rebrand theme `triple-hyde`
+* Add support for Mastodon in sidebar
+* Add support for image short codes
 
 __2018-11__
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ __`Triple-hyde`__ is a [Hugo](https://gohugo.io)'s theme that extends @htrn's [H
 
 `hyde-hyde` has been paused in development for awhile, this fork implements the following changes:
 
-* [PR #1](https://github.com/derme302/triple-hyde/pull/1) Adds support for Google Analytics v4
-* [PR #5](https://github.com/derme302/triple-hyde/pull/5) by [@eatingbrb](https://github.com/eatingbrb) Adds support for Mastodon in social sidebar
+* [PR #1](https://github.com/derme302/triple-hyde/pull/1) adds support for Google Analytics v4
+* [PR #5](https://github.com/derme302/triple-hyde/pull/5) by [@eatingbrb](https://github.com/eatingbrb) adds support for Mastodon in social sidebar
+* [PR #6](https://github.com/derme302/triple-hyde/pull/5) adds support for img shortcodes, allowing you to align an image inside of markdown by adding `#center`, `#left` or `#right` at the end of an image link. E.g. `![Metal](/uploads/2014/06/metal_icon.png#center)`
 
 For more details, please refer to [CHANGELOG](https://github.com/derme302/triple-hyde/blob/master/CHANGELOG.md).  A real site in action can be found [here](https://derme.coffee/) and the [example site](https://derme.coffee/triple-hyde) for reference.
 

--- a/assets/scss/triple-hyde/_shortcodes.scss
+++ b/assets/scss/triple-hyde/_shortcodes.scss
@@ -1,0 +1,14 @@
+img[src$='#center'] {
+    display: block;
+    margin: 0.7rem auto;
+}
+
+img[src$='#floatleft'] {
+    float:left;
+    margin: 0.7rem;
+}
+
+img[src$='#floatright'] {
+    float:right;
+    margin: 0.7rem;
+}

--- a/assets/scss/triple-hyde/_variables.scss
+++ b/assets/scss/triple-hyde/_variables.scss
@@ -17,6 +17,7 @@ $green: #90a959;
 $cyan: #75b5aa;
 $blue: #268bd2;
 $brown: #8f5536;
+$purple: #76c;
 
 //https://www.client9.com/css-system-font-stack-sans-serif-v3
 $root-font-family: "IBM Plex Sans", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Droid Sans", "Ubuntu", "Helvetica Neue", Helvetica, Arial, sans-serif, "Apple Color Emoji","Segoe UI Emoji", "Segoe UI Symbol";


### PR DESCRIPTION
Adds support for img shortcodes, allowing you to align an image inside of markdown by adding `#center`, `#left` or `#right` at the end of an image link. E.g. `![Metal](/uploads/2014/06/metal_icon.png#center)`